### PR TITLE
Update ts: alternative to #5

### DIFF
--- a/scripts-base/package-lock.json
+++ b/scripts-base/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     }
   }

--- a/scripts-base/package.json
+++ b/scripts-base/package.json
@@ -15,7 +15,7 @@
   "author": "manGoweb <info@mangoweb.cz> (https://mangoweb.cz)",
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^3.1.6"
+    "typescript": "^3.5.1"
   },
   "prepare": "npm run build",
   "publishConfig": {

--- a/scripts-base/src/components/InView.ts
+++ b/scripts-base/src/components/InView.ts
@@ -41,6 +41,9 @@ export class InView extends Component<InViewData> {
 			(entries) => {
 				//callback
 				entries.forEach((entry) => {
+					if (!entry.rootBounds) {
+						return
+					}
 					const target = entry.target
 					const intersectionRatio = entry.intersectionRatio
 					this._updateState(

--- a/scripts-base/src/types.d.ts
+++ b/scripts-base/src/types.d.ts
@@ -15,16 +15,17 @@ type DelegateEvent<E extends BubblingEventType> = HTMLElementEventMap[E] & {
 	delegateTarget: HTMLElement
 }
 
+type DelegateEventListenerCallback<E extends BubblingEventType> = (event: DelegateEvent<E>) => void
+
 type DelegateEventListenerSpec<E extends BubblingEventType> = [
 	E,
 	string,
-	(event: DelegateEvent<E>) => void
+	DelegateEventListenerCallback<E>
 ]
 
-type EventListenerSpec<E extends keyof HTMLElementEventMap> = [
-	E,
-	(event: HTMLElementEventMap[E]) => void
-]
+type EventListenerCallback<E extends keyof HTMLElementEventMap> = (event: HTMLElementEventMap[E]) => void
+
+type EventListenerSpec<E extends keyof HTMLElementEventMap> = [E, EventListenerCallback<E>]
 
 type EventListeners = Array<
 	| { [E in keyof HTMLElementEventMap]: EventListenerSpec<E> }[keyof HTMLElementEventMap]

--- a/scripts-base/src/utils/inject.ts
+++ b/scripts-base/src/utils/inject.ts
@@ -1,9 +1,7 @@
 const head = document.head
 const noop = () => {}
 
-type ScriptElementConfig = {
-	[P in Exclude<keyof HTMLScriptElement, keyof HTMLElement>]?: HTMLScriptElement[P]
-}
+type ScriptElementConfig = Partial<Omit<HTMLScriptElement, keyof HTMLElement>>
 type ScriptConfig = ScriptElementConfig & { content: string }
 
 export const inject = (
@@ -30,8 +28,8 @@ export const inject = (
 			} else {
 				const keyCast = key as keyof ScriptElementConfig
 
-				if (options[keyCast]) {
-					script[keyCast] = options[keyCast]!
+				if (options[keyCast] !== undefined) {
+					(script as any)[keyCast] = options[keyCast]
 				}
 			}
 		}


### PR DESCRIPTION
This is a largely unfortunate duplicate of #5, although it, I believe, addresses the issues at hand slightly better.

Rationale comparing these changes to #5:

1. TS can be somewhat unpredictable at times, and so fixing its version to `^3.5.1` shoul be more stable, and thus preferable to `^3.5.x`. We can always release new versions if need be.
2. The casts in `Component.ts` are strictly *more specific* than those in #5, and thus are slightly less of an unfortunate workaround.
3. The early return in `InView.ts` is more elegant than a large branch.
4. Albeit at the expense of an `as any` cast, the changes in `inject.ts` still rely on setting _properties_ as opposed to _attributes_, which is the correct approach.