### PR TITLE
Generic elements

### DIFF
--- a/scripts-base/.eslintrc.js
+++ b/scripts-base/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	extends:  [
+		'@mangoweb/eslint-config-ts',
+	]
+};

--- a/scripts-base/.prettierrc.js
+++ b/scripts-base/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	...require('@mangoweb/prettier-config')
+}

--- a/scripts-base/README.md
+++ b/scripts-base/README.md
@@ -47,7 +47,7 @@ You must:
 - Inherit from `Component`
 - Define `static componentName: string`
 ```typescript
-import { Component } from '@mangoweb/scripts-base'
+import { Component, DelegateEvent, EventListeners } from '@mangoweb/scripts-base'
 
 interface MyComponentData {
 	foo: number
@@ -74,6 +74,17 @@ export class MyComponent extends Component<MyComponentData> {
 	}
 }
 ```
+
+The `Component` superclass accepts up to three generic parameters, all of which are optional. The first one, the
+structure of `data`, defaults to `{}`. The second one is the type of `el`. It defaults to `HTMLElement` but is useful
+to change when we want to assert that it is something else (e.g. `Window`, `HTMLBodyElement`, `SVGElement`, etc.).
+
+The last parameter should only be necessary to change in very extreme situations. It is the map from supported event
+types to their respective `Event` objects. It should be inferred from the type of `el`, although it may be necessary
+to change, should the standard library prove to be incomplete.
+
+The `EventListeners` return type of `getListeners` optionally accepts the same two parameters as the last two of
+`Components`. It may be necessary to specify one or both if inference fails.
 
 #### Life-cycle methods
 The following happens to your component during initialization (in that order):

--- a/scripts-base/package-lock.json
+++ b/scripts-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangoweb/scripts-base",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -37,6 +37,15 @@
         "eslint-plugin-react-hooks": "^1.6.0",
         "prettier": "^1.17.0",
         "typescript": "^3.5.1"
+      }
+    },
+    "@mangoweb/prettier-config": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mangoweb/prettier-config/-/prettier-config-0.0.0.tgz",
+      "integrity": "sha512-GSmsyuxQCVJb00pEZQq5zVnd+9830BwyG1WUQKc0M4gIDk79KRBcgs81pMuNmpoo559ez4Y4/XZ1FeLjELpd/g==",
+      "dev": true,
+      "requires": {
+        "prettier": "^1.17.0"
       }
     },
     "@types/eslint-visitor-keys": {

--- a/scripts-base/package-lock.json
+++ b/scripts-base/package-lock.json
@@ -1,14 +1,1326 @@
 {
   "name": "@mangoweb/scripts-base",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@mangoweb/eslint-config-ts": {
+      "version": "0.0.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/eslint-plugin": "^1.9.0",
+        "@typescript-eslint/parser": "^1.9.0",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-plugin-prettier": "^3.1.0",
+        "eslint-plugin-react": "^7.13.0",
+        "eslint-plugin-react-hooks": "^1.6.0",
+        "prettier": "^1.17.0",
+        "typescript": "^3.5.1"
+      }
+    },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.11.0.tgz",
+      "integrity": "sha512-mXv9ccCou89C8/4avKHuPB2WkSZyY/XcTQUXd5LFZAcLw1I3mWYVjUu6eS9Ja0QkP/ClolbcW9tb3Ov/pMdcqw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "1.11.0",
+        "eslint-utils": "^1.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.11.0.tgz",
+      "integrity": "sha512-7LbfaqF6B8oa8cp/315zxKk8FFzosRzzhF8Kn/ZRsRsnpm7Qcu25cR/9RnAQo5utZ2KIWVgaALr+ZmcbG47ruw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.11.0",
+        "eslint-scope": "^4.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.11.0.tgz",
+      "integrity": "sha512-5xBExyXaxVyczrZvbRKEXvaTUFFq7gIM9BynXukXZE0zF3IQP/FxF4mPmmh3gJ9egafZFqByCpPTFm3dk4SY7Q==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "1.11.0",
+        "@typescript-eslint/typescript-estree": "1.11.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.11.0.tgz",
+      "integrity": "sha512-fquUHF5tAx1sM2OeRCC7wVxFd1iMELWMGCzOSmJ3pLzArj9+kRixdlC4d5MncuzXpjEqc6045p3KwM0o/3FuUA==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      }
+    },
+    "acorn": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-5.0.0.tgz",
+      "integrity": "sha512-c17Aqiz5e8LEqoc/QPmYnaxQFAHTx2KlCZBPxXXjEMmNchOLnV/7j0HoPZuC+rL/tDC9bazUYOKJW9bOhftI/w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.0.tgz",
+      "integrity": "sha512-MbPYPGsOteqqnFZx4lGLw6izxcWv6onLsil/6iX6+CaZAzMxOwsPja1Xg25cVCJ4jwKBDhJXe+ZAn6HAjGHSCw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+      "integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
+      "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+      "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
+      "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
+      "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "typescript": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
       "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     }
   }
 }

--- a/scripts-base/package.json
+++ b/scripts-base/package.json
@@ -6,7 +6,9 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "tsc",
+    "eslint:lint": "eslint \"src/**/*.{ts,tsx}\" ",
+    "eslint:fix": "eslint --fix \"src/**/*.{ts,tsx}\" "
   },
   "repository": {
     "type": "git",
@@ -15,6 +17,16 @@
   "author": "manGoweb <info@mangoweb.cz> (https://mangoweb.cz)",
   "license": "MIT",
   "devDependencies": {
+    "@mangoweb/eslint-config-ts": "^0.0.0",
+    "@mangoweb/prettier-config": "^0.0.0",
+    "@typescript-eslint/eslint-plugin": "^1.9.0",
+    "@typescript-eslint/parser": "^1.9.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^5.0.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-react": "^7.13.0",
+    "eslint-plugin-react-hooks": "^1.6.0",
+    "prettier": "^1.17.0",
     "typescript": "^3.5.1"
   },
   "prepare": "npm run build",

--- a/scripts-base/package.json
+++ b/scripts-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangoweb/scripts-base",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Simple component model for small to meduim sites. Usable from JS & TS.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/scripts-base/src/Component.ts
+++ b/scripts-base/src/Component.ts
@@ -49,18 +49,18 @@ export class Component<
 		return child
 	}
 
-	protected getChildren<C extends DelegateTarget<ComponentElement>>(
+	protected getChildren<Children extends DelegateTarget<ComponentElement>>(
 		selector: string,
 		parent = this.el as HTMLElement | SVGElement
 	) {
-		return parent.querySelectorAll(selector) as NodeListOf<C>
+		return parent.querySelectorAll(selector) as NodeListOf<Children>
 	}
 
-	protected getProp<N extends keyof Data>(
-		prop: N,
-		defaultValue: Exclude<Data[N], undefined>
-	): Exclude<Data[N], undefined> {
-		return this.data[prop] === undefined ? defaultValue : (this.data[prop] as Exclude<Data[N], undefined>)
+	protected getProp<PropName extends keyof Data>(
+		prop: PropName,
+		defaultValue: Exclude<Data[PropName], undefined>
+	): Exclude<Data[PropName], undefined> {
+		return this.data[prop] === undefined ? defaultValue : (this.data[prop] as Exclude<Data[PropName], undefined>)
 	}
 
 	public init() {}

--- a/scripts-base/src/Component.ts
+++ b/scripts-base/src/Component.ts
@@ -8,15 +8,14 @@ import {
 } from './componentTypes'
 import { matchesSelector } from './utils'
 
-export interface NamedComponent {
-	componentName: string
-}
-
-export type ComponentConstructor<
+export interface ComponentConstructor<
 	Data,
 	ComponentElement extends ComponentEl,
 	EMap extends EventMap = EventMapByElement<ComponentElement>
-> = NamedComponent & (new (element: ComponentElement, data: Data) => Component<Data, ComponentElement, EMap>)
+> {
+	componentName: string
+	new (element: ComponentElement, data: Data): Component<Data, ComponentElement, EMap>
+}
 
 export class ComponentInitializationError extends Error {}
 

--- a/scripts-base/src/Component.ts
+++ b/scripts-base/src/Component.ts
@@ -1,4 +1,12 @@
-import { matchesSelector } from '../utils'
+import {
+	ComponentEl,
+	DelegateEvent,
+	DelegateTarget,
+	EventListeners,
+	EventMap,
+	EventMapByElement,
+} from './componentTypes'
+import { matchesSelector } from './utils'
 
 export interface NamedComponent {
 	componentName: string
@@ -25,7 +33,7 @@ export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends
 
 	protected getChild<C extends DelegateTarget<E>>(
 		selector: string,
-		ChildConstructor: Constructor<C>,
+		ChildConstructor: new (...args: any[]) => C,
 		parent: HTMLElement | SVGElement = this.el as HTMLElement | SVGElement
 	): C {
 		const child = parent.querySelector(selector)

--- a/scripts-base/src/Component.ts
+++ b/scripts-base/src/Component.ts
@@ -13,29 +13,32 @@ export interface NamedComponent {
 }
 
 export type ComponentConstructor<
-	D,
-	E extends ComponentEl,
-	EMap extends EventMap = EventMapByElement<E>
-> = NamedComponent & (new (element: E, data: D) => Component<D, E, EMap>)
+	Data,
+	ComponentElement extends ComponentEl,
+	EMap extends EventMap = EventMapByElement<ComponentElement>
+> = NamedComponent & (new (element: ComponentElement, data: Data) => Component<Data, ComponentElement, EMap>)
 
 export class ComponentInitializationError extends Error {}
 
-export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends EventMap = EventMapByElement<E>> {
-	protected readonly getListeners = (): EventListeners<E, EMap> => []
+export class Component<
+	Data = {},
+	ComponentElement extends ComponentEl = HTMLElement,
+	EMap extends EventMap = EventMapByElement<ComponentElement>
+> {
+	protected readonly getListeners = (): EventListeners<ComponentElement, EMap> => []
 
-	constructor(protected readonly el: E, protected readonly data: D) {}
+	constructor(protected readonly el: ComponentElement, protected readonly data: Data) {}
 
 	public setup() {
 		this.attachListeners()
-
 		this.init()
 	}
 
-	protected getChild<C extends DelegateTarget<E>>(
+	protected getChild<Child extends DelegateTarget<ComponentElement>>(
 		selector: string,
-		ChildConstructor: new (...args: any[]) => C,
+		ChildConstructor: new (...args: any[]) => Child,
 		parent: HTMLElement | SVGElement = this.el as HTMLElement | SVGElement
-	): C {
+	): Child {
 		const child = parent.querySelector(selector)
 
 		if (!(child instanceof ChildConstructor)) {
@@ -46,12 +49,18 @@ export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends
 		return child
 	}
 
-	protected getChildren<C extends DelegateTarget<E>>(selector: string, parent = this.el as HTMLElement | SVGElement) {
+	protected getChildren<C extends DelegateTarget<ComponentElement>>(
+		selector: string,
+		parent = this.el as HTMLElement | SVGElement
+	) {
 		return parent.querySelectorAll(selector) as NodeListOf<C>
 	}
 
-	protected getProp<N extends keyof D>(prop: N, defaultValue: Exclude<D[N], undefined>): Exclude<D[N], undefined> {
-		return this.data[prop] === undefined ? defaultValue : (this.data[prop] as Exclude<D[N], undefined>)
+	protected getProp<N extends keyof Data>(
+		prop: N,
+		defaultValue: Exclude<Data[N], undefined>
+	): Exclude<Data[N], undefined> {
+		return this.data[prop] === undefined ? defaultValue : (this.data[prop] as Exclude<Data[N], undefined>)
 	}
 
 	public init() {}
@@ -79,8 +88,8 @@ export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends
 
 						while (target && target !== this.el && target instanceof Element) {
 							if (matchesSelector(target, delegateSelector)) {
-								const delegateEvent = (e as unknown) as DelegateEvent<typeof type, E, EMap>
-								delegateEvent.delegateTarget = target as DelegateTarget<E>
+								const delegateEvent = (e as unknown) as DelegateEvent<typeof type, ComponentElement, EMap>
+								delegateEvent.delegateTarget = target as DelegateTarget<ComponentElement>
 
 								return callback.call(this, delegateEvent)
 							}

--- a/scripts-base/src/componentTypes.ts
+++ b/scripts-base/src/componentTypes.ts
@@ -1,6 +1,6 @@
-type ComponentEl = HTMLElement | SVGElement | Window
+export type ComponentEl = HTMLElement | SVGElement | Window
 
-type EventMapByElement<E> = E extends Window
+export type EventMapByElement<E> = E extends Window
 	? WindowEventMap
 	: E extends SVGElement
 	? SVGElementEventMap
@@ -14,7 +14,7 @@ type EventMapByElement<E> = E extends Window
 	? HTMLElementEventMap
 	: never
 
-type DelegateTarget<Container extends ComponentEl> = Container extends Window
+export type DelegateTarget<Container extends ComponentEl> = Container extends Window
 	? HTMLElement | SVGElement
 	: Container extends SVGElement
 	? SVGElement
@@ -22,7 +22,7 @@ type DelegateTarget<Container extends ComponentEl> = Container extends Window
 	? HTMLElement | SVGElement
 	: never
 
-type EventMap =
+export type EventMap =
 	| WindowEventMap
 	| SVGElementEventMap
 	| HTMLBodyElementEventMap
@@ -30,7 +30,7 @@ type EventMap =
 	| HTMLMediaElementEventMap
 	| HTMLElementEventMap
 
-type NonBubblingEventType =
+export type NonBubblingEventType =
 	| 'abort'
 	| 'blur'
 	| 'error'
@@ -41,9 +41,9 @@ type NonBubblingEventType =
 	| 'progress'
 	| 'scroll'
 
-type BubblingEventType<EMap extends EventMap> = Exclude<keyof EMap, NonBubblingEventType>
+export type BubblingEventType<EMap extends EventMap> = Exclude<keyof EMap, NonBubblingEventType>
 
-type DelegateEvent<
+export type DelegateEvent<
 	E extends BubblingEventType<EMap>,
 	Container extends ComponentEl = HTMLElement,
 	EMap extends EventMap = EventMapByElement<Container>
@@ -51,28 +51,26 @@ type DelegateEvent<
 	delegateTarget: DelegateTarget<Container>
 }
 
-type DelegateEventListenerCallback<
+export type DelegateEventListenerCallback<
 	E extends BubblingEventType<EMap>,
-	Container extends ComponentEl,
-	EMap extends EventMap
+	Container extends ComponentEl = HTMLElement,
+	EMap extends EventMap = EventMapByElement<Container>
 > = (event: DelegateEvent<E, Container, EMap>) => void
 
-type DelegateEventListenerSpec<
+export type DelegateEventListenerSpec<
 	E extends BubblingEventType<EMap>,
-	Container extends ComponentEl,
-	EMap extends EventMap
+	Container extends ComponentEl = HTMLElement,
+	EMap extends EventMap = EventMapByElement<Container>
 > = [E, string, DelegateEventListenerCallback<E, Container, EMap>]
 
-type EventListenerCallback<E extends keyof EMap, EMap extends EventMap> = (event: EMap[E]) => void
+export type EventListenerCallback<E extends keyof EMap, EMap extends EventMap> = (event: EMap[E]) => void
 
-type EventListenerSpec<E extends keyof EMap, EMap extends EventMap> = [E, EventListenerCallback<E, EMap>]
+export type EventListenerSpec<E extends keyof EMap, EMap extends EventMap> = [E, EventListenerCallback<E, EMap>]
 
-type EventListeners<
+export type EventListeners<
 	Container extends ComponentEl = HTMLElement,
 	EMap extends EventMap = EventMapByElement<Container>
 > = Array<
 	| { [E in keyof EMap]: EventListenerSpec<E, EMap> }[keyof EMap]
 	| { [E in BubblingEventType<EMap>]: DelegateEventListenerSpec<E, Container, EMap> }[BubblingEventType<EMap>]
 >
-
-type Constructor<T> = new (...args: any[]) => T

--- a/scripts-base/src/componentTypes.ts
+++ b/scripts-base/src/componentTypes.ts
@@ -2,17 +2,15 @@ export type ComponentEl = HTMLElement | SVGElement | Window
 
 export type EventMapByElement<E> = E extends Window
 	? WindowEventMap
-	: E extends SVGElement
-	? SVGElementEventMap
-	: E extends HTMLBodyElement
-	? HTMLBodyElementEventMap
-	: E extends HTMLVideoElement
-	? HTMLVideoElementEventMap
-	: E extends HTMLAudioElement
-	? HTMLMediaElementEventMap
-	: E extends HTMLElement
-	? HTMLElementEventMap
-	: never
+	: (E extends SVGElement
+			? SVGElementEventMap
+			: (E extends HTMLBodyElement
+					? HTMLBodyElementEventMap
+					: (E extends HTMLVideoElement
+							? HTMLVideoElementEventMap
+							: (E extends HTMLAudioElement
+									? HTMLMediaElementEventMap
+									: (E extends HTMLElement ? HTMLElementEventMap : never)))))
 
 export type DelegateTarget<Container extends ComponentEl> = Container extends Window
 	? HTMLElement | SVGElement

--- a/scripts-base/src/componentTypes.ts
+++ b/scripts-base/src/componentTypes.ts
@@ -1,6 +1,6 @@
 export type ComponentEl = HTMLElement | SVGElement | Window
 
-export type EventMapByElement<E> = E extends Window
+export type EventMapByElement<E extends ComponentEl> = E extends Window
 	? WindowEventMap
 	: (E extends SVGElement
 			? SVGElementEventMap

--- a/scripts-base/src/components/Component.ts
+++ b/scripts-base/src/components/Component.ts
@@ -10,15 +10,12 @@ export type ComponentConstructor<D, E extends HTMLElement = HTMLElement> = Named
 export class ComponentInitializationError extends Error {}
 
 export class Component<D, E extends HTMLElement = HTMLElement> {
-	protected readonly el: E
-	protected readonly data: D
 
 	protected getListeners = (): EventListeners => []
 
-	constructor(element: E, data: D) {
-		this.el = element
-		this.data = data
-	}
+	constructor(
+		protected readonly el: E,
+		protected readonly data: D) {}
 
 	public setup() {
 		this.attachListeners()

--- a/scripts-base/src/components/Component.ts
+++ b/scripts-base/src/components/Component.ts
@@ -4,12 +4,12 @@ export interface NamedComponent {
 	componentName: string
 }
 
-export type ComponentConstructor<D, E extends HTMLElement = HTMLElement> = NamedComponent &
+export type ComponentConstructor<D, E extends HTMLElement> = NamedComponent &
 	(new (element: E, data: D) => Component<D, E>)
 
 export class ComponentInitializationError extends Error {}
 
-export class Component<D, E extends HTMLElement = HTMLElement> {
+export class Component<D = {}, E extends HTMLElement = HTMLElement> {
 
 	protected getListeners = (): EventListeners => []
 

--- a/scripts-base/src/components/Component.ts
+++ b/scripts-base/src/components/Component.ts
@@ -4,23 +4,18 @@ export interface NamedComponent {
 	componentName: string
 }
 
+export type ComponentConstructor<
+	D,
+	E extends ComponentEl,
+	EMap extends EventMap = EventMapByElement<E>
+> = NamedComponent & (new (element: E, data: D) => Component<D, E, EMap>)
 
-export type ComponentConstructor<D, E extends ComponentEl, EMap extends EventMap = EventMapByElement<E>> =
-	NamedComponent
-	&
-	(new (element: E, data: D) => Component<D, E, EMap>)
-
-export class ComponentInitializationError extends Error {
-}
+export class ComponentInitializationError extends Error {}
 
 export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends EventMap = EventMapByElement<E>> {
-
 	protected readonly getListeners = (): EventListeners<E, EMap> => []
 
-	constructor(
-		protected readonly el: E,
-		protected readonly data: D) {
-	}
+	constructor(protected readonly el: E, protected readonly data: D) {}
 
 	public setup() {
 		this.attachListeners()
@@ -51,8 +46,7 @@ export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends
 		return this.data[prop] === undefined ? defaultValue : (this.data[prop] as Exclude<D[N], undefined>)
 	}
 
-	public init() {
-	}
+	public init() {}
 
 	private attachListeners() {
 		const listeners = this.getListeners()
@@ -63,7 +57,7 @@ export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends
 			if (listenersSpec.length === 2) {
 				// EventListenerSpec
 				const type = listenersSpec[0] as string
-				const callback = listenersSpec[1].bind(this) as CallableFunction as (evt: Event) => void
+				const callback = (listenersSpec[1].bind(this) as CallableFunction) as (evt: Event) => void
 
 				this.el.addEventListener(type, callback, false)
 			} else {
@@ -77,10 +71,10 @@ export class Component<D = {}, E extends ComponentEl = HTMLElement, EMap extends
 
 						while (target && target !== this.el && target instanceof Element) {
 							if (matchesSelector(target, delegateSelector)) {
-								const delegateEvent = e as unknown as DelegateEvent<typeof type, E, EMap>
+								const delegateEvent = (e as unknown) as DelegateEvent<typeof type, E, EMap>
 								delegateEvent.delegateTarget = target as DelegateTarget<E>
 
-								return (callback).call(this, delegateEvent)
+								return callback.call(this, delegateEvent)
 							}
 
 							target = target.parentElement

--- a/scripts-base/src/components/Emitter.ts
+++ b/scripts-base/src/components/Emitter.ts
@@ -29,7 +29,7 @@ export class Emitter extends Component<EmitterData> {
 	private handleClick(e: MouseEvent) {
 		e.preventDefault()
 
-		this.events.map((eventType) => {
+		this.events.map(eventType => {
 			const event = document.createEvent('Event')
 
 			event.initEvent(eventType, true, true)

--- a/scripts-base/src/components/Emitter.ts
+++ b/scripts-base/src/components/Emitter.ts
@@ -1,4 +1,5 @@
-import { Component } from './Component'
+import { EventListeners } from '../componentTypes'
+import { Component } from '../Component'
 
 type EventType = string
 type Events = Array<EventType>

--- a/scripts-base/src/components/Example.ts
+++ b/scripts-base/src/components/Example.ts
@@ -19,9 +19,7 @@ export class Example extends Component<ExampleData> {
 
 	private handleDelegateClick(e: DelegateEvent<'click'>): void {
 		console.log(e.delegateTarget)
-		alert(
-			`Hello, ${this.data.name}! The number of the day is ${this.data.numberOfTheDay.toFixed(0)}.`
-		)
+		alert(`Hello, ${this.data.name}! The number of the day is ${this.data.numberOfTheDay.toFixed(0)}.`)
 	}
 
 	private handleClick(e: MouseEvent): void {

--- a/scripts-base/src/components/Example.ts
+++ b/scripts-base/src/components/Example.ts
@@ -1,4 +1,5 @@
-import { Component } from './Component'
+import { Component } from '../Component'
+import { DelegateEvent, EventListeners } from '../componentTypes'
 
 interface ExampleData {
 	name: string

--- a/scripts-base/src/components/InView.ts
+++ b/scripts-base/src/components/InView.ts
@@ -16,10 +16,10 @@ export class InView extends Component<InViewData> {
 	private readonly detectOnce: boolean
 	private readonly strictTop: boolean
 
-	private readonly CLASSES = Object.freeze({
+	private readonly CLASSES = {
 		topThreshold: 'view-topThreshold',
 		bottomThreshold: 'view-bottomThreshold',
-	})
+	} as const
 
 	public constructor(el: HTMLElement, data: InViewData) {
 		super(el, data)

--- a/scripts-base/src/components/InView.ts
+++ b/scripts-base/src/components/InView.ts
@@ -38,19 +38,15 @@ export class InView extends Component<InViewData> {
 
 	private observerInit() {
 		const observer = new IntersectionObserver(
-			(entries) => {
+			entries => {
 				//callback
-				entries.forEach((entry) => {
+				entries.forEach(entry => {
 					if (!entry.rootBounds) {
 						return
 					}
 					const target = entry.target
 					const intersectionRatio = entry.intersectionRatio
-					this._updateState(
-						target,
-						intersectionRatio,
-						entry.boundingClientRect.top < entry.rootBounds.height / 2
-					)
+					this._updateState(target, intersectionRatio, entry.boundingClientRect.top < entry.rootBounds.height / 2)
 				})
 			},
 			{
@@ -74,14 +70,9 @@ export class InView extends Component<InViewData> {
 					const intersectionArea =
 						Math.max(
 							0,
-							Math.min(targetRect.left + targetRect.width, window.innerWidth) -
-								Math.max(targetRect.left, 0)
+							Math.min(targetRect.left + targetRect.width, window.innerWidth) - Math.max(targetRect.left, 0)
 						) * // width
-						Math.max(
-							0,
-							Math.min(targetRect.top + targetRect.height, window.innerHeight) -
-								Math.max(targetRect.top, 0)
-						) // height
+						Math.max(0, Math.min(targetRect.top + targetRect.height, window.innerHeight) - Math.max(targetRect.top, 0)) // height
 					const intersectionRatio = intersectionArea / targetArea
 					this._updateState(target, intersectionRatio, targetRect.top < window.innerHeight / 2)
 				}
@@ -93,15 +84,12 @@ export class InView extends Component<InViewData> {
 	_updateState(target: any, intersectionRatio: number, targetTopAboveViewCenter: boolean) {
 		const hasTopClassThreshold: boolean = target.classList.contains(this.CLASSES.topThreshold)
 		const hasBottomClassThreshold: boolean = target.classList.contains(this.CLASSES.bottomThreshold)
-		const strictTop =
-			this.data.hasOwnProperty('detectOnce') && this.data.strictTop ? this.threshold : 0
+		const strictTop = this.data.hasOwnProperty('detectOnce') && this.data.strictTop ? this.threshold : 0
 		const topThreshold = hasTopClassThreshold ? strictTop : this.threshold
 		const isTop =
-			(this.detectOnce && hasTopClassThreshold) ||
-			(intersectionRatio > topThreshold || targetTopAboveViewCenter)
+			(this.detectOnce && hasTopClassThreshold) || (intersectionRatio > topThreshold || targetTopAboveViewCenter)
 		const isBottom =
-			(this.detectOnce && hasBottomClassThreshold) ||
-			(intersectionRatio <= this.threshold && targetTopAboveViewCenter)
+			(this.detectOnce && hasBottomClassThreshold) || (intersectionRatio <= this.threshold && targetTopAboveViewCenter)
 		target.classList.toggle(this.CLASSES.topThreshold, isTop)
 		target.classList.toggle(this.CLASSES.bottomThreshold, isBottom)
 		if (this.data.afterUpdate) {

--- a/scripts-base/src/components/InView.ts
+++ b/scripts-base/src/components/InView.ts
@@ -1,4 +1,4 @@
-import { Component } from './Component'
+import { Component } from '../Component'
 
 interface InViewData {
 	targets?: string

--- a/scripts-base/src/components/Shapes.ts
+++ b/scripts-base/src/components/Shapes.ts
@@ -1,4 +1,4 @@
-import { Component } from './Component'
+import { Component } from '../Component'
 
 export interface ShapesData {
 	url: string

--- a/scripts-base/src/components/Shapes.ts
+++ b/scripts-base/src/components/Shapes.ts
@@ -13,10 +13,8 @@ export class Shapes extends Component<ShapesData> {
 	static componentName = 'Shapes'
 
 	init() {
-		document.implementation.hasFeature(
-			'http://www.w3.org/TR/SVG11/feature#BasicStructure',
-			'1.1'
-		) && this.injectSprite()
+		document.implementation.hasFeature('http://www.w3.org/TR/SVG11/feature#BasicStructure', '1.1') &&
+			this.injectSprite()
 	}
 
 	injectSprite(): void {

--- a/scripts-base/src/components/index.ts
+++ b/scripts-base/src/components/index.ts
@@ -1,4 +1,3 @@
-export * from './Component'
 export * from './Emitter'
 export * from './Example'
 export * from './InView'

--- a/scripts-base/src/extensions.d.ts
+++ b/scripts-base/src/extensions.d.ts
@@ -1,0 +1,8 @@
+interface Element {
+	msMatchesSelector(selectors: string): boolean
+}
+
+interface HTMLElementEventMap {
+	focusin: FocusEvent
+	focusout: FocusEvent
+}

--- a/scripts-base/src/globals.d.ts
+++ b/scripts-base/src/globals.d.ts
@@ -1,10 +1,10 @@
-declare const DEBUG: boolean
-
 interface ComponentDefinition {
 	name: string
 	place?: keyof HTMLElementTagNameMap | HTMLElement
 	data?: any
 }
+
+declare const DEBUG: boolean
 
 type ComponentInitializer =
 	| Array<ComponentDefinition>

--- a/scripts-base/src/index.ts
+++ b/scripts-base/src/index.ts
@@ -1,6 +1,8 @@
 /// <reference path="extensions.d.ts" />
 /// <reference path="globals.d.ts" />
-/// <reference path="types.d.ts" />
+
+export * from './Component'
+export * from './componentTypes'
 
 export * from './components'
 export * from './utils'

--- a/scripts-base/src/index.ts
+++ b/scripts-base/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference path="extensions.d.ts" />
 /// <reference path="globals.d.ts" />
 /// <reference path="types.d.ts" />
 

--- a/scripts-base/src/initializeComponents.ts
+++ b/scripts-base/src/initializeComponents.ts
@@ -1,7 +1,7 @@
 import { Component, ComponentConstructor, ComponentInitializationError, } from './components'
 
 export const initializeComponents = (
-	components: Array<ComponentConstructor<any, any>>,
+	components: Array<ComponentConstructor<any, any, any>>,
 	initializerName: ComponentInitializerName = 'initComponents'
 ) => {
 	const componentsByName: {

--- a/scripts-base/src/initializeComponents.ts
+++ b/scripts-base/src/initializeComponents.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentConstructor, ComponentInitializationError, } from './components'
+import { Component, ComponentConstructor, ComponentInitializationError } from './components'
 
 export const initializeComponents = (
 	components: Array<ComponentConstructor<any, any, any>>,
@@ -27,9 +27,7 @@ export const initializeComponents = (
 			const Component = componentsByName[component.name] // class
 
 			const placement =
-				typeof component.place === 'string'
-					? document.querySelector(component.place)
-					: component.place || document.body
+				typeof component.place === 'string' ? document.querySelector(component.place) : component.place || document.body
 
 			if (placement) {
 				try {
@@ -43,17 +41,13 @@ export const initializeComponents = (
 				}
 			} else if (DEBUG) {
 				console.warn(
-					`Trying to initialize component '${component.name}' but its selector '${
-						component.place
-						}' was not found`
+					`Trying to initialize component '${component.name}' but its selector '${component.place}' was not found`
 				)
 			}
 
 			if (DEBUG) {
 				const componentEndTime = performance.now()
-				console.log(
-					`\tComponent: ${component.name}: ${Math.round(componentEndTime - componentStartTime)}ms`
-				)
+				console.log(`\tComponent: ${component.name}: ${Math.round(componentEndTime - componentStartTime)}ms`)
 			}
 		} else if (DEBUG) {
 			console.warn(`Component with name ${component.name} was not found!`)

--- a/scripts-base/src/initializeComponents.ts
+++ b/scripts-base/src/initializeComponents.ts
@@ -1,11 +1,12 @@
-import { Component, ComponentConstructor, ComponentInitializationError } from './Component'
+import { ComponentConstructor, ComponentInitializationError } from './Component'
+import { ComponentEl } from './componentTypes'
 
 export const initializeComponents = (
-	components: Array<ComponentConstructor<any, any, any>>,
+	components: Array<ComponentConstructor<unknown, ComponentEl>>,
 	initializerName: ComponentInitializerName = 'initComponents'
 ) => {
 	const componentsByName: {
-		[name: string]: typeof Component
+		[name: string]: ComponentConstructor<unknown, ComponentEl>
 	} = {}
 
 	for (let i = 0, length = components.length; i < length; i++) {

--- a/scripts-base/src/initializeComponents.ts
+++ b/scripts-base/src/initializeComponents.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentConstructor, ComponentInitializationError } from './components'
+import { Component, ComponentConstructor, ComponentInitializationError } from './Component'
 
 export const initializeComponents = (
 	components: Array<ComponentConstructor<any, any, any>>,

--- a/scripts-base/src/types.d.ts
+++ b/scripts-base/src/types.d.ts
@@ -1,3 +1,27 @@
+type ComponentEl = HTMLElement | SVGElement | Window
+
+type EventMapByElement<E> =
+	E extends Window ? WindowEventMap :
+		E extends SVGElement ? SVGElementEventMap :
+			E extends HTMLBodyElement ? HTMLBodyElementEventMap :
+				E extends HTMLVideoElement ? HTMLVideoElementEventMap :
+					E extends HTMLAudioElement ? HTMLMediaElementEventMap :
+						E extends HTMLElement ? HTMLElementEventMap : never
+
+type DelegateTarget<Container extends ComponentEl> =
+	Container extends Window ? HTMLElement | SVGElement :
+		Container extends SVGElement ? SVGElement :
+			Container extends HTMLElement ? HTMLElement | SVGElement :
+				never
+
+type EventMap =
+	WindowEventMap
+	| SVGElementEventMap
+	| HTMLBodyElementEventMap
+	| HTMLVideoElementEventMap
+	| HTMLMediaElementEventMap
+	| HTMLElementEventMap
+
 type NonBubblingEventType =
 	| 'abort'
 	| 'blur'
@@ -9,27 +33,27 @@ type NonBubblingEventType =
 	| 'progress'
 	| 'scroll'
 
-type BubblingEventType = Exclude<keyof HTMLElementEventMap, NonBubblingEventType>
+type BubblingEventType<EMap extends EventMap> = Exclude<keyof EMap, NonBubblingEventType>
 
-type DelegateEvent<E extends BubblingEventType> = HTMLElementEventMap[E] & {
-	delegateTarget: HTMLElement
+type DelegateEvent<E extends BubblingEventType<EMap>, Container extends ComponentEl = HTMLElement, EMap extends EventMap = EventMapByElement<Container>> =
+	EMap[E]
+	& {
+	delegateTarget: DelegateTarget<Container>
 }
 
-type DelegateEventListenerCallback<E extends BubblingEventType> = (event: DelegateEvent<E>) => void
+type DelegateEventListenerCallback<E extends BubblingEventType<EMap>, Container extends ComponentEl, EMap extends EventMap> = (event: DelegateEvent<E, Container, EMap>) => void
 
-type DelegateEventListenerSpec<E extends BubblingEventType> = [
+type DelegateEventListenerSpec<E extends BubblingEventType<EMap>, Container extends ComponentEl, EMap extends EventMap> = [
 	E,
 	string,
-	DelegateEventListenerCallback<E>
+	DelegateEventListenerCallback<E, Container, EMap>
 ]
 
-type EventListenerCallback<E extends keyof HTMLElementEventMap> = (event: HTMLElementEventMap[E]) => void
+type EventListenerCallback<E extends keyof EMap, EMap extends EventMap> = (event: EMap[E]) => void
 
-type EventListenerSpec<E extends keyof HTMLElementEventMap> = [E, EventListenerCallback<E>]
+type EventListenerSpec<E extends keyof EMap, EMap extends EventMap> = [E, EventListenerCallback<E, EMap>]
 
-type EventListeners = Array<
-	| { [E in keyof HTMLElementEventMap]: EventListenerSpec<E> }[keyof HTMLElementEventMap]
-	| { [E in BubblingEventType]: DelegateEventListenerSpec<E> }[BubblingEventType]
->
+type EventListeners<Container extends ComponentEl = HTMLElement, EMap extends EventMap = EventMapByElement<Container>> = Array<{ [E in keyof EMap]: EventListenerSpec<E, EMap> }[keyof EMap]
+	| { [E in BubblingEventType<EMap>]: DelegateEventListenerSpec<E, Container, EMap> }[BubblingEventType<EMap>]>
 
 type Constructor<T> = new (...args: any[]) => T

--- a/scripts-base/src/types.d.ts
+++ b/scripts-base/src/types.d.ts
@@ -33,12 +33,3 @@ type EventListeners = Array<
 >
 
 type Constructor<T> = new (...args: any[]) => T
-
-interface Element {
-	msMatchesSelector(selectors: string): boolean
-}
-
-interface HTMLElementEventMap {
-	focusin: FocusEvent
-	focusout: FocusEvent
-}

--- a/scripts-base/src/types.d.ts
+++ b/scripts-base/src/types.d.ts
@@ -1,21 +1,29 @@
 type ComponentEl = HTMLElement | SVGElement | Window
 
-type EventMapByElement<E> =
-	E extends Window ? WindowEventMap :
-		E extends SVGElement ? SVGElementEventMap :
-			E extends HTMLBodyElement ? HTMLBodyElementEventMap :
-				E extends HTMLVideoElement ? HTMLVideoElementEventMap :
-					E extends HTMLAudioElement ? HTMLMediaElementEventMap :
-						E extends HTMLElement ? HTMLElementEventMap : never
+type EventMapByElement<E> = E extends Window
+	? WindowEventMap
+	: E extends SVGElement
+	? SVGElementEventMap
+	: E extends HTMLBodyElement
+	? HTMLBodyElementEventMap
+	: E extends HTMLVideoElement
+	? HTMLVideoElementEventMap
+	: E extends HTMLAudioElement
+	? HTMLMediaElementEventMap
+	: E extends HTMLElement
+	? HTMLElementEventMap
+	: never
 
-type DelegateTarget<Container extends ComponentEl> =
-	Container extends Window ? HTMLElement | SVGElement :
-		Container extends SVGElement ? SVGElement :
-			Container extends HTMLElement ? HTMLElement | SVGElement :
-				never
+type DelegateTarget<Container extends ComponentEl> = Container extends Window
+	? HTMLElement | SVGElement
+	: Container extends SVGElement
+	? SVGElement
+	: Container extends HTMLElement
+	? HTMLElement | SVGElement
+	: never
 
 type EventMap =
-	WindowEventMap
+	| WindowEventMap
 	| SVGElementEventMap
 	| HTMLBodyElementEventMap
 	| HTMLVideoElementEventMap
@@ -35,25 +43,36 @@ type NonBubblingEventType =
 
 type BubblingEventType<EMap extends EventMap> = Exclude<keyof EMap, NonBubblingEventType>
 
-type DelegateEvent<E extends BubblingEventType<EMap>, Container extends ComponentEl = HTMLElement, EMap extends EventMap = EventMapByElement<Container>> =
-	EMap[E]
-	& {
+type DelegateEvent<
+	E extends BubblingEventType<EMap>,
+	Container extends ComponentEl = HTMLElement,
+	EMap extends EventMap = EventMapByElement<Container>
+> = EMap[E] & {
 	delegateTarget: DelegateTarget<Container>
 }
 
-type DelegateEventListenerCallback<E extends BubblingEventType<EMap>, Container extends ComponentEl, EMap extends EventMap> = (event: DelegateEvent<E, Container, EMap>) => void
+type DelegateEventListenerCallback<
+	E extends BubblingEventType<EMap>,
+	Container extends ComponentEl,
+	EMap extends EventMap
+> = (event: DelegateEvent<E, Container, EMap>) => void
 
-type DelegateEventListenerSpec<E extends BubblingEventType<EMap>, Container extends ComponentEl, EMap extends EventMap> = [
-	E,
-	string,
-	DelegateEventListenerCallback<E, Container, EMap>
-]
+type DelegateEventListenerSpec<
+	E extends BubblingEventType<EMap>,
+	Container extends ComponentEl,
+	EMap extends EventMap
+> = [E, string, DelegateEventListenerCallback<E, Container, EMap>]
 
 type EventListenerCallback<E extends keyof EMap, EMap extends EventMap> = (event: EMap[E]) => void
 
 type EventListenerSpec<E extends keyof EMap, EMap extends EventMap> = [E, EventListenerCallback<E, EMap>]
 
-type EventListeners<Container extends ComponentEl = HTMLElement, EMap extends EventMap = EventMapByElement<Container>> = Array<{ [E in keyof EMap]: EventListenerSpec<E, EMap> }[keyof EMap]
-	| { [E in BubblingEventType<EMap>]: DelegateEventListenerSpec<E, Container, EMap> }[BubblingEventType<EMap>]>
+type EventListeners<
+	Container extends ComponentEl = HTMLElement,
+	EMap extends EventMap = EventMapByElement<Container>
+> = Array<
+	| { [E in keyof EMap]: EventListenerSpec<E, EMap> }[keyof EMap]
+	| { [E in BubblingEventType<EMap>]: DelegateEventListenerSpec<E, Container, EMap> }[BubblingEventType<EMap>]
+>
 
 type Constructor<T> = new (...args: any[]) => T

--- a/scripts-base/src/utils/filterNodeList.ts
+++ b/scripts-base/src/utils/filterNodeList.ts
@@ -1,4 +1,6 @@
 import { matchesSelector } from './matchesSelector'
 
-export const filterNodeList = <E extends HTMLElement>(list: NodeListOf<E> | HTMLCollectionOf<E>, selector: string): Array<E> =>
-	Array.prototype.filter.call(list, (item: E) => matchesSelector(item, selector))
+export const filterNodeList = <E extends HTMLElement>(
+	list: NodeListOf<E> | HTMLCollectionOf<E>,
+	selector: string
+): Array<E> => Array.prototype.filter.call(list, (item: E) => matchesSelector(item, selector))

--- a/scripts-base/src/utils/inject.ts
+++ b/scripts-base/src/utils/inject.ts
@@ -29,7 +29,7 @@ export const inject = (
 				const keyCast = key as keyof ScriptElementConfig
 
 				if (options[keyCast] !== undefined) {
-					(script as any)[keyCast] = options[keyCast]
+					;(script as any)[keyCast] = options[keyCast]
 				}
 			}
 		}


### PR DESCRIPTION
This one will be a bit tough to review.

- It adopts the new coding style packages, which meant a couple of stylistic changes. It still fails one linting rule, the one about triple slash directives. I do plan to get rid of them eventually but it will have to wait for now.
- `Component` was changed fairly significantly *and* moved, which is too much for GitHub's diff, I guess. The main point of the change is that we can now systemically specify the type of `this.el` and it shows in the kind of events we can listen to. For instance, if we extend `Component<{}, HTMLAudioElement>`, we can listen to the `play` event, which was not possible earlier as `Component` just used `HTMLElementEventMap`. As for the file move, this was done in prep for splitting the package into smaller ones where the components (and perhaps the utils too) are distributed separately.

There is a BC break that requires use-site imports of the relevant types. This could look a bit like
```typescript
import { Component, DelegateEvent, EventListeners } from '@mangoweb/scripts-base'
```
People with IDEs from the 21st century should never have to write that manually though, and so I don't really see that as a problem. The change happened so as to get rid of one the triple slash directives.