### PR TITLE
matchesSelector: Fix for IE11

### DIFF
--- a/scripts-base/src/utils/matchesSelector.ts
+++ b/scripts-base/src/utils/matchesSelector.ts
@@ -1,3 +1,9 @@
 export const matchesSelector = (element: Element, selector: string): boolean => {
-	return (element.matches || element.msMatchesSelector).call(element, selector)
+	let matches = false
+	try {
+		matches = (element.matches || element.msMatchesSelector).call(element, selector)
+	} catch (e) {
+		// Fails on invalid or unknown selectors
+	}
+	return matches
 }


### PR DESCRIPTION
IE11 will throw an error on perfectly fine `::backdrop` selector. This change handles these cases silently with false return value.