### PR TITLE
Pr/hiding header/common component

### DIFF
--- a/scripts-components/hiding-header/README.md
+++ b/scripts-components/hiding-header/README.md
@@ -17,9 +17,7 @@ This is a [`@mangoweb/scripts-base`](https://www.npmjs.com/package/@mangoweb/scr
 <body>
 	<div class="hidingHeader" id="hidingHeader">
 		<div class="hidingHeader-in">
-			<div class="hidingHeader-content">
-				<!-- Your header -->
-			</div>
+			<!-- Your header -->
 		</div>
 	</div>
 	<script>
@@ -50,9 +48,6 @@ This is a [`@mangoweb/scripts-base`](https://www.npmjs.com/package/@mangoweb/scr
 	position: relative;
 	position: sticky;
 	top: 0;
-}
-
-.hidingHeader-content {
 	pointer-events: auto;
 }
 ```

--- a/scripts-components/hiding-header/README.md
+++ b/scripts-components/hiding-header/README.md
@@ -36,11 +36,11 @@ This is a [`@mangoweb/scripts-base`](https://www.npmjs.com/package/@mangoweb/scr
 ```css
 .hidingHeader {
 	position: relative;
-	--hidingHeader-height: 0px;
-	--hidingHeader-scrollCap: 0px;
+	--hidingHeader-height: auto;
+	--hidingHeader-bounds-height: auto;
 	z-index: 10;
-	min-height: calc(var(--hidingHeader-scrollCap) + var(--hidingHeader-height));
-	margin-bottom: calc(-1 * var(--hidingHeader-scrollCap));
+	height: var(--hidingHeader-bounds-height);
+	margin-bottom: calc(var(--hidingHeader-height) - var(--hidingHeader-bounds-height));
 	pointer-events: none;
 }
 

--- a/scripts-components/hiding-header/package-lock.json
+++ b/scripts-components/hiding-header/package-lock.json
@@ -1028,6 +1028,12 @@
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
+		"hiding-header": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/hiding-header/-/hiding-header-0.1.4.tgz",
+			"integrity": "sha512-L9NUseGtxHqXW54fulRstaMLwwnPvRalM1EyYpzTq5NEEhaFhKpjkKjPjUJBlKOPnQMtk7WTaj4I2nZPagtbwQ==",
+			"dev": true
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/scripts-components/hiding-header/package.json
+++ b/scripts-components/hiding-header/package.json
@@ -28,6 +28,7 @@
 		"eslint-plugin-prettier": "^3.1.1",
 		"eslint-plugin-react": "^7.16.0",
 		"eslint-plugin-react-hooks": "^2.2.0",
+		"hiding-header": "^0.1.4",
 		"prettier": "^1.19.1",
 		"typescript": "^3.7.2"
 	},

--- a/scripts-components/hiding-header/src/index.ts
+++ b/scripts-components/hiding-header/src/index.ts
@@ -1,56 +1,12 @@
 import { Component } from '@mangoweb/scripts-base'
+import { hidingHeader } from 'hiding-header'
 
-export interface HidingHeaderProps {
-	contentSelector?: string
-	heightPropertyName?: string
-	scrollCapPropertyName?: string
-}
-
-const DEFAULT_CONTENT_SELECTOR = '*'
-const DEFAULT_HEIGHT_PROPERTY_NAME = '--hidingHeader-height'
-const DEFAULT_SCROLL_CAP_PROPERTY_NAME = '--hidingHeader-scrollCap'
+export interface HidingHeaderProps {}
 
 export class HidingHeader extends Component<HidingHeaderProps> {
 	static componentName = 'HidingHeader'
 
-	protected lastScrollTop = 0
-	protected contentHeight = 0
-	protected content = this.getChild(this.getPropOrElse('contentSelector', DEFAULT_CONTENT_SELECTOR), HTMLElement)
-	protected wasScrollingDown = true
-	protected lastScrollCap = 0
-	protected heightPropertyName = this.getPropOrElse('heightPropertyName', DEFAULT_HEIGHT_PROPERTY_NAME)
-	protected scrollCapPropertyName = this.getPropOrElse('scrollCapPropertyName', DEFAULT_SCROLL_CAP_PROPERTY_NAME)
-
-	getContentHeight() {
-		return this.content.clientHeight
-	}
-
 	init() {
-		window.addEventListener('scroll', this.onScroll)
-		window.addEventListener('resize', this.onScroll)
-		this.onScroll()
-	}
-
-	onScroll = () => {
-		const contentHeight = this.getContentHeight() // @TODO: throttle/cache
-		if (this.contentHeight !== contentHeight) {
-			this.contentHeight = contentHeight
-			this.el.style.setProperty(this.heightPropertyName, `${contentHeight}px`)
-		}
-
-		const scrollTop = window.scrollY
-		const isScrollingDown = scrollTop > this.lastScrollTop
-		if (isScrollingDown !== this.wasScrollingDown) {
-			const scrollCap = isScrollingDown ? scrollTop : Math.max(0, scrollTop - contentHeight)
-
-			// @TODO: handle changes in scroll direction if header is partially visible
-
-			if (scrollCap !== this.lastScrollCap) {
-				this.wasScrollingDown = isScrollingDown
-				this.el.style.setProperty(this.scrollCapPropertyName, `${scrollCap}px`)
-				this.lastScrollCap = scrollCap
-			}
-		}
-		this.lastScrollTop = scrollTop
+		hidingHeader(this.el)
 	}
 }


### PR DESCRIPTION
Napojení na knihovnu, která řeší stejný problém podobným kódem => snazší udržitelnost.

(Je to za cenu toho, že nejdou například customizovat názvy custom properties, ale to se dá klidně dopsat až ve chvíli, kdy to bude potřeba.)